### PR TITLE
7 update detection struct to match darknet

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ As of today, OpenCV DNN doesn't support GPU acceleration for NVIDA (no idea abou
 
 Simply put:
 * Compile it with GPU
+* Only builds of darknet from 2019-10-25 or later should be used with zmMagik due to a change in the darknet data structures
 * Make sure it is actually using GPU
 * then set `gpu=True` and `darknet_lib=<path/to/filename of gpu accelerated so>`
 * If you need help compiling darknet for GPU and CUDA 10.x, see [simpleYolo](https://github.com/pliablepixels/simpleYolo)

--- a/zmMagik_helpers/simpleyolo/simpleYolo.py
+++ b/zmMagik_helpers/simpleyolo/simpleYolo.py
@@ -183,7 +183,9 @@ class DETECTION(Structure):
                 ("prob", POINTER(c_float)),
                 ("mask", POINTER(c_float)),
                 ("objectness", c_float),
-                ("sort_class", c_int)]
+                ("sort_class", c_int),
+                ("uc", POINTER(c_float)),
+                ("points", c_int)]
 
 class IMAGE(Structure):
     _fields_ = [("w", c_int),


### PR DESCRIPTION
On 2019-10-25, darknet was updated to add the Gaussian YOLOv3 layer. This had the effect of changing the detection structure in darknet.h that zmMagik uses to interface to darknet. This commit updates zmMagik to account for the new structure. Unfortunately, the darknet version was not updated to reflect this change. For this reason, only builds of darknet from 2019-10-25 or later should be used with zmMagik.